### PR TITLE
Tweak to the Ed guide

### DIFF
--- a/Source/relay/Guide/Paths/Actually Ed the Undying.ash
+++ b/Source/relay/Guide/Paths/Actually Ed the Undying.ash
@@ -177,6 +177,123 @@ void PathActuallyEdtheUndyingGenerateTasks(ChecklistEntry [int] task_entries, Ch
         optional_task_entries.listAppend(ChecklistEntryMake(image_name, "place.php?whichplace=edbase&action=edbase_book", ChecklistSubentryMake("Buy Undying skills", "", description_buy_skills)));
     }
 
+    int spleen_limit = spleen_limit();
+    if ( spleen_limit < 35 )
+    {
+        /* The absolutely most important, crucial thing to do is get
+           Ed to have as many adventures as possible.  That mostly
+           involves upgrading his spleen.
+
+           This next bit sorts out how many adventures need to be
+           spent to purchase the spleen, AND the haunch to fill it...
+           ...and the oft-forgotten extra adventure to actually buy it all.
+           Nothing worse than having the exact amount of Ka, but 0 adventures
+           left, so no access to the underworld.
+         */
+        int ka_needed_for_spleen = 0;
+        int available_ka = $item[Ka coin].available_amount();
+        string [int] description;
+
+        if ( spleen_limit == 5 )
+        {
+            /* Extra Spleen */
+            description.listAppend("Buy an extra spleen (5 Ka)");
+            ka_needed_for_spleen += 5;
+        }
+        else if ( spleen_limit == 10 )
+        {
+            /* Another Extra Spleen */
+            description.listAppend("Buy another extra spleen (10 Ka)");
+            ka_needed_for_spleen += 10;
+        }
+        else if ( spleen_limit == 15 )
+        {
+            /* Yet Another Extra Spleen */
+            description.listAppend("Buy yet another extra spleen (15 Ka)");
+            ka_needed_for_spleen += 15;
+        }
+        else if ( spleen_limit == 20 )
+        {
+            /* Still Another Extra Spleen */
+            description.listAppend("Buy still another extra spleen (20 Ka)");
+            ka_needed_for_spleen += 20;
+        }
+        else if ( spleen_limit == 25 )
+        {
+            /* Just One More Extra Spleen */
+            description.listAppend("Buy just one more extra spleen (25 Ka)");
+            ka_needed_for_spleen += 25;
+        }
+        else if ( spleen_limit == 30 )
+        {
+            /* TODO worth recommending getting the liver and|or stomach here */
+            /* The Final Spleen */
+            description.listAppend("Buy the final spleen (30 Ka)");
+            ka_needed_for_spleen += 30;
+        }
+
+        int total_adventures_needed = 1; /* to go actually buy this stuff */
+
+        available_ka -= ka_needed_for_spleen;
+        if ( available_ka < 0 )
+        {
+            int adventures_needed_farming_for_spleen
+                = ceil(ka_needed_for_spleen.to_float() / 2.0);
+            description.listAppend("Have to spend " + adventures_needed_farming_for_spleen + " adventures farming at 2 Ka per adventure");
+            total_adventures_needed += adventures_needed_farming_for_spleen;
+        }
+
+        if ( available_ka < 0 )
+            available_ka = 0;
+
+        int [item] spleen_item_to_ka;
+        spleen_item_to_ka[ $item[mummified fig]           ] =  5;
+        spleen_item_to_ka[ $item[mummified loaf of bread] ] = 10;
+        spleen_item_to_ka[ $item[mummified beef haunch]   ] = 15;
+        string consumable_desc = "";
+        foreach spleen_item in $items[mummified beef haunch, mummified loaf of bread, mummified fig]
+        {
+            if (spleen_item.available_amount() > 0)
+                break;
+            int ka_cost = spleen_item_to_ka[spleen_item];
+
+            if ( available_ka > ka_cost ) /* got enough for a consumable */
+                break;
+
+            int adventures_needed = ceil((ka_cost-available_ka).to_float() / 2.0);
+
+            if ( consumable_desc.length() > 0 )
+            {
+                consumable_desc += ", or ";
+            }
+            else
+            {
+                total_adventures_needed += adventures_needed;
+            }
+            consumable_desc += "+" + adventures_needed + " adventures for a " + spleen_item.to_string();
+        }
+
+        if ( consumable_desc.length() > 0 )
+            description.listAppend("Plus " + consumable_desc);
+
+        description.listAppend("1 adventure needed to go to the underworld");
+
+        string running_out_of_adventures = "";
+        int adventures_left = my_adventures();
+        if (
+            total_adventures_needed < adventures_left
+                &&
+            total_adventures_needed > (adventures_left-5)
+        ) {
+            // running out of adventures, farm now!
+            running_out_of_adventures = "red";
+        }
+
+        description.listAppend(HTMLGenerateSpanFont("Total adventures needed: ~" + total_adventures_needed, running_out_of_adventures));
+
+        task_entries.listAppend(ChecklistEntryMake("__skill extra spleen", "", ChecklistSubentryMake("Upgrade spleen for more adventures", "", description), 0));
+    }
+
     if (my_level() >= 13 && QuestState("questL13Final").finished)
     {
         if ($item[7965].available_amount() > 0 || $item[2334].available_amount() > 0) //holy macguffins

--- a/Source/relay/Guide/Paths/Actually Ed the Undying.ash
+++ b/Source/relay/Guide/Paths/Actually Ed the Undying.ash
@@ -168,23 +168,55 @@ void PathActuallyEdtheUndyingGenerateResource(ChecklistEntry [int] resource_entr
         ka_table.listAppend(listMake("talisman of Renenutet", 1, "+lots item for one combat"));
         //body upgrades:
         string [int][int] skill_upgrade_order;
+
+        // Upgraded legs allows for early farming of hippies/pirates, so
+        // it should be priority number one
+        skill_upgrade_order.listAppend(listMake("Upgraded Legs", 10, "+50% init"));
         skill_upgrade_order.listAppend(listMake("Extra Spleen", 5, "+5 spleen"));
         skill_upgrade_order.listAppend(listMake("Another Extra Spleen", 10, "+5 spleen"));
         skill_upgrade_order.listAppend(listMake("Yet Another Extra Spleen", 15, "+5 spleen"));
         skill_upgrade_order.listAppend(listMake("Still Another Extra Spleen", 20, "+5 spleen"));
-        skill_upgrade_order.listAppend(listMake("Replacement Stomach", 30, "+5 stomach")); //fortune cookie
+
+        /* XXX might want liver early anyway, as it allows for overdrinking */
+        boolean early_liver = false;
+        if (
+            $item[astral six-pack].is_unrestricted()
+                ||
+            $item[astral pilsner].is_unrestricted()
+        ) {
+            early_liver = true;
+            //Got astral booze
+            skill_upgrade_order.listAppend(listMake("Replacement Liver", 30, "can drink"));
+        }
+        else {
+            skill_upgrade_order.listAppend(listMake("Replacement Stomach", 30, "+5 stomach")); //fortune cookie
+        }
+
         skill_upgrade_order.listAppend(listMake("Just One More Extra Spleen", 25, "+5 spleen"));
         skill_upgrade_order.listAppend(listMake("Okay Seriously, This is the Last Spleen", 30, "+5 spleen"));
-        skill_upgrade_order.listAppend(listMake("Replacement Liver", 30, "can drink"));
-        skill_upgrade_order.listAppend(listMake("Upgraded Legs", 10, "+50% init"));
+
+        if ( !early_liver ) {
+            skill_upgrade_order.listAppend(listMake("Replacement Liver", 30, "can drink"));
+        }
+        else {
+            //Got astral booze
+            skill_upgrade_order.listAppend(listMake("Replacement Stomach", 30, "+5 stomach")); //fortune cookie
+        }
+
         skill_upgrade_order.listAppend(listMake("More Legs", 20, "+50% init"));
+        // Wards can come in late; mainly useful for Big Mountain & A-boo
         skill_upgrade_order.listAppend(listMake("Elemental Wards", 10, "+1 all res"));
         skill_upgrade_order.listAppend(listMake("More Elemental Wards", 20, "+2 all res"));
+        // DA & DR are useful during the war; allows flyers & magnet on
+        // the gremlins for example.
         skill_upgrade_order.listAppend(listMake("Tougher Skin", 10, "+100 DA"));
+        skill_upgrade_order.listAppend(listMake("Armor Plating", 10, "+10 DR")); //marginal
+
+        // A-boo
         skill_upgrade_order.listAppend(listMake("Even More Elemental Wards", 30, "+3 all res"));
+
         skill_upgrade_order.listAppend(listMake("Upgraded Spine", 20, "+50% moxie"));
         skill_upgrade_order.listAppend(listMake("Upgraded Arms", 20, "+50% muscle"));
-        skill_upgrade_order.listAppend(listMake("Armor Plating", 10, "+10 DR")); //marginal
         //skill_upgrade_order.listAppend(listMake("Bone Spikes", 20));
         //skill_upgrade_order.listAppend(listMake("Arm Blade", 20));
         //skill_upgrade_order.listAppend(listMake("Healing Scarabs")); //only useful if it prevents beaten up from non-combats?

--- a/Source/relay/Guide/Paths/Actually Ed the Undying.ash
+++ b/Source/relay/Guide/Paths/Actually Ed the Undying.ash
@@ -246,7 +246,13 @@ void PathActuallyEdtheUndyingGenerateResource(ChecklistEntry [int] resource_entr
             places_to_farm_ka.listAppend("hippy camp");
             if (url.length() == 0) url = $location[hippy camp].getClickableURLForLocation();
         }
-        
+
+        if ( !__misc_state["mysterious island available"] )
+        {
+            places_to_farm_ka.listAppend("The Sleazy Back Alley (at ~1.5 Ka/adv, best to use the time unlocking the hippy camp)");
+            if (url.length() == 0) url = $location[The Sleazy Back Alley].getClickableURLForLocation();
+        }
+
         if (places_to_farm_ka.count() > 0)
             description.listAppend("Could farm ka in the " + places_to_farm_ka.listJoinComponents(", ", "or") + ".");
         


### PR DESCRIPTION
Howdy!

Well, first of all -- You guide made my first ascension after coming back to the game ~7 years later FAR less stressful than anything I remember before.  I played KoL before ascension existed, and played it again for a while in 2010, and I can say with no doubt that your guide is what I always wish I had 👍 

Moving on, this pull request!  I'm doing my first ever Actually Ed the Undying ascension, and made a bunch of dumb mistakes, somewhat chronicled in the commit messages.  The commits add a couple of quality of life improvements, mainly aimed at newer people like me:

- Task to nudge people towards the spleen upgrades
- Skill progression recommendations for people with <6 Ed skills (aka get fist of the mummy feredssake)
- Ed buff reminders (to keep the +stats & +ML buffs going mainly)
- Body upgrade progression was swapped a bit (upgraded legs before everything)

Do let me know if the content fits with what you aim to do in the guide.

Also, I have never done any .ash before -- not super sure what the language is -- but I tested the changes locally and they all work for me. That is admittedly a very low bar! No guarantees that I haven't massively screwed up or put code in the wrong place! :)