### PR TITLE
don't recommend buying black paint if in Ed run

### DIFF
--- a/Source/relay/Guide/Quests/Level 11.ash
+++ b/Source/relay/Guide/Quests/Level 11.ash
@@ -163,7 +163,7 @@ void QLevel11BaseGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry
             image_name = "__item forged identification documents";
             url = "shop.php?whichshop=blackmarket";
             subentry.entries.listAppend("From the black market");
-            if ($item[can of black paint].available_amount() == 0)
+            if ($item[can of black paint].available_amount() == 0 && my_path_id() != PATH_ACTUALLY_ED_THE_UNDYING)
                 subentry.entries.listAppend("Also buy a can of black paint while you're there, for the desert quest.");
         }
         else


### PR DESCRIPTION
Ezandora, love your guide; I've been doing a few Ed runs and noticed the guide recommended buying the black paint, but Ed runs don't need the black paint because Ed doesn't do the desert stuff in the McGuffin quest.  I have not tested this change, but it seemed a simple enough change that it was still worth passing along to you.